### PR TITLE
Normalize channel names prefixed by `#`

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -47,7 +47,8 @@ function Commander (view, cabal) {
     join: {
       help: () => 'join a new channel',
       call: (arg) => {
-        if (arg === '') arg = 'default'
+        if (arg === '') arg = '#default'
+        else if (!arg.startsWith('#')) arg = `#${arg}`
         self.channel = arg
         self.view.loadChannel(arg)
       }

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -134,7 +134,7 @@ function NeatScreen (cabal) {
       if (err) return
       self.state.cabal.channels = channels
       // load initial state of the channel
-      self.loadChannel('default')
+      self.loadChannel('#default')
     })
   })
   // self.cabal.on('join', (username) => {


### PR DESCRIPTION
I implemented it in the command, we could also patch this in `cabal-node` but I think it's best to keep freedom in the low-level library.