### PR TITLE
NPX valid license identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "p2p"
   ],
   "author": "cblgh",
-  "license": "AGPL",
+  "license": "AGPL-3.0-or-later",
   "bugs": {
     "url": "https://github.com/cabal-club/cabal/issues"
   },


### PR DESCRIPTION
Sorry about that thought AGPL would work but I got a warning about it being not SPX valid. This one is correct according to https://spdx.org/licenses/ :). 