### PR TITLE
Save your nick and key aliases to a config file

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -3,11 +3,13 @@ var Cabal = require('cabal-node')
 var cabalSwarm = require('cabal-node/swarm.js')
 var minimist = require('minimist')
 var frontend = require('./neat-screen.js')
+var fs = require('fs')
 
 var args = minimist(process.argv.slice(2))
 
 var homedir = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE
 var rootdir = homedir + '/.cabal/archives/'
+var configPath = homedir + '/.cabal/config.json'
 
 var usage = `Usage
 
@@ -23,6 +25,16 @@ var usage = `Usage
 
 Work in progress! Learn more at github.com/cabal-club
 `
+
+if (fs.existsSync(configPath)) {
+  try {
+    var config = JSON.parse('testconfig.json')
+  } catch (SyntaxError e) {
+    console.error("Something is wrong with your config.")
+  }
+} else {
+  // generate default config
+}
 
 if (args.key) {
   args.key = args.key.replace('dat://', '').replace(/\//g, '')

--- a/cli.js
+++ b/cli.js
@@ -27,8 +27,8 @@ var usage = `Usage
 
     --nick <name>         Use <name> as nick for this session
     --seeder              Start a headless seeder for the specified cabal key
-    --new-alias <name>    Add an alias to your config. Must be used with --key
-    --config-nick <name>  Set <name> as your default nick from now on
+    --set-alias <name>    Add an alias to your config. Must be used with --key
+    --set-nick <name>  Set <name> as your default nick from now on
 
 Work in progress! Learn more at github.com/cabal-club
 `
@@ -53,11 +53,18 @@ if (fs.existsSync(configPath)) {
   saveConfig(config)
 }
 
-if (args['new-alias']) {
+
+var key = args.key || config.keyAliases[args._[0]]
+
+if (key) {
+  key = key.replace('dat://', '').replace(/\//g, '')
+  args.db = rootdir + key
+}
+
+if (args['set-alias']) {
   if (args.key) {
-    config.keyAliases[args['new-alias']] = args.key
+    config.keyAliases[args['set-alias']] = args.key
     saveConfig(config)
-    process.stdout.write("alias " + args['new-alias'] + " saved.\n")
     process.exit(0)
   } else {
     process.stderr.write(usage)
@@ -65,18 +72,12 @@ if (args['new-alias']) {
   }
 }
 
-if (args['config-nick']) {
-  config.nick = args['config-nick']
+if (args['set-nick']) {
+  config.nick = args['set-nick']
   saveConfig(config)
-  process.stdout.write("nick " + args['config-nick'] + " saved.\n")
-  process.exit(0)
-}
-
-var key = args.key || config.keyAliases[args._[0]]
-
-if (key) {
-  key = key.replace('dat://', '').replace(/\//g, '')
-  args.db = rootdir + key
+  if (!args.db) {
+    process.exit(0)
+  }
 }
 
 if (!args.db) {

--- a/testconf.json
+++ b/testconf.json
@@ -1,4 +1,0 @@
-{
-  "nick" : "voidcase",
-  "keys" : {}
-}

--- a/testconf.json
+++ b/testconf.json
@@ -1,0 +1,4 @@
+{
+  "nick" : "voidcase",
+  "keys" : {}
+}


### PR DESCRIPTION
Added options for setting nick and making aliases for keys.

    cabal --config-nick voidcase

    cabal --new-alias meta --key dat://21b2b9ff201b01e6081709d82e6b81a5cf3a68d2cd5f092d0ffec58772642892
Aliases are used with

     cabal meta