### PR TITLE
Fix crash when resizing to really small width (edge case)

### DIFF
--- a/util.js
+++ b/util.js
@@ -60,8 +60,8 @@ function strlenAnsi (str) {
 function centerText (text, width) {
   var left = Math.floor((width - strlenAnsi(text)) / 2)
   var right = Math.ceil((width - strlenAnsi(text)) / 2)
-  var lspace = new Array(left).fill(' ').join('')
-  var rspace = new Array(right).fill(' ').join('')
+  var lspace = left > 0 ? new Array(left).fill(' ').join('') : ''
+  var rspace = right > 0 ? new Array(right).fill(' ').join('') : ''
   return lspace + text + rspace
 }
 


### PR DESCRIPTION
Fixes:

```
lms@x240 ~/src/cabal (master)
$ node cli.js --key dat://7d99b453506b9743bf5e71fe749f66c814d7cd9388a5d394a27eed4c5640302b --nick rtn
/home/lms/src/cabal/util.js:63
  var lspace = new Array(left).fill(' ').join('')
               ^

RangeError: Invalid array length
    at Object.centerText (/home/lms/src/cabal/util.js:63:16)
    at renderTitlebar (/home/lms/src/cabal/views.js:66:23)
    at Object.small (/home/lms/src/cabal/views.js:14:16)
    at Array.view (/home/lms/src/cabal/neat-screen.js:149:23)
    at Diffy._render (/home/lms/src/cabal/node_modules/neat-log/index.js:52:46)
    at Diffy.render (/home/lms/src/cabal/node_modules/diffy/index.js:57:42)
    at render (/home/lms/src/cabal/node_modules/neat-log/index.js:51:11)
    at process._tickCallback (internal/process/next_tick.js:61:11)
```

Same problem happens for `right` (I noticed this once I fixed the `left` edge case).