### PR TITLE
Add an option to send a single message then quit

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -81,5 +81,5 @@ function publishSingleMessage ({channel, message, messageType, timeout}) {
     }
   })
   swarm(cabal)
-  setTimeout(function () { process.exit(1) }, timeout)
+  setTimeout(function () { process.exit(0) }, timeout)
 }

--- a/cli.js
+++ b/cli.js
@@ -19,7 +19,12 @@ var usage = `Usage
 
   Options:
 
-    --seed  Start a headless seed for the specified cabal key
+    --seed    Start a headless seed for the specified cabal key
+
+    --message Publish a single message; then quit after \`timeout\`
+    --channel Channel name to publish to for \`message\` option; default: "default"
+    --timeout Delay in milliseconds to wait on swarm before quitting for \`message\` option; default: 5000
+    --type    Message type set to message for \`message\` option; default: "chat/text"
 
 Work in progress! Learn more at github.com/cabal-club
 `
@@ -30,6 +35,15 @@ if (args.key) {
 
   var cabal = Cabal(args.db, args.key)
   cabal.db.ready(function () {
+    if (args.message) {
+      publishSingleMessage({
+        channel: args.channel || 'default',
+        message: args.message,
+        messageType: args.type || 'chat/text',
+        timeout: args.timeout || 5000
+      })
+      return
+    }
     start(args.key)
   })
 } else {
@@ -55,4 +69,17 @@ function start (key) {
     console.log('Seeding', key)
     swarm(cabal)
   }
+}
+
+function publishSingleMessage ({channel, message, messageType, timeout}) {
+  console.log('Publishing message to channel - ' + channel + ': "' + message + '"...')
+  cabal.publish({
+    type: messageType,
+    content: {
+      channel: channel,
+      text: message
+    }
+  })
+  swarm(cabal)
+  setTimeout(function () { process.exit(1) }, timeout)
 }

--- a/cli.js
+++ b/cli.js
@@ -37,10 +37,10 @@ if (args.key) {
   cabal.db.ready(function () {
     if (args.message) {
       publishSingleMessage({
-        channel: args.channel || 'default',
+        channel: args.channel,
         message: args.message,
-        messageType: args.type || 'chat/text',
-        timeout: args.timeout || 5000
+        messageType: args.type,
+        timeout: args.timeout
       })
       return
     }
@@ -51,6 +51,15 @@ if (args.key) {
   cabal.db.ready(function () {
     cabal.getLocalKey(function (err, key) {
       if (err) throw err
+      if (args.message) {
+        publishSingleMessage({
+          channel: args.channel,
+          message: args.message,
+          messageType: args.type,
+          timeout: args.timeout
+        })
+        return
+      }
       start(key)
     })
   })
@@ -74,12 +83,12 @@ function start (key) {
 function publishSingleMessage ({channel, message, messageType, timeout}) {
   console.log('Publishing message to channel - ' + channel + ': "' + message + '"...')
   cabal.publish({
-    type: messageType,
+    type: messageType || 'chat/text',
     content: {
-      channel: channel,
+      channel: channel || 'default',
       text: message
     }
   })
   swarm(cabal)
-  setTimeout(function () { process.exit(0) }, timeout)
+  setTimeout(function () { process.exit(0) }, timeout || 5000)
 }

--- a/cli.js
+++ b/cli.js
@@ -35,15 +35,6 @@ if (args.key) {
 
   var cabal = Cabal(args.db, args.key)
   cabal.db.ready(function () {
-    if (args.message) {
-      publishSingleMessage({
-        channel: args.channel,
-        message: args.message,
-        messageType: args.type,
-        timeout: args.timeout
-      })
-      return
-    }
     start(args.key)
   })
 } else {
@@ -51,15 +42,6 @@ if (args.key) {
   cabal.db.ready(function () {
     cabal.getLocalKey(function (err, key) {
       if (err) throw err
-      if (args.message) {
-        publishSingleMessage({
-          channel: args.channel,
-          message: args.message,
-          messageType: args.type,
-          timeout: args.timeout
-        })
-        return
-      }
       start(key)
     })
   })
@@ -72,6 +54,15 @@ if (!args.db) {
 
 function start (key) {
   if (!args.seed) {
+    if (args.message) {
+      publishSingleMessage({
+        channel: args.channel,
+        message: args.message,
+        messageType: args.type,
+        timeout: args.timeout
+      })
+      return
+    }
     frontend(cabal)
     setTimeout(function () { swarm(cabal) }, 300)
   } else {


### PR DESCRIPTION
I know right now we’re looking for sanity instead of features but I thought this might be helpful for scripting maybe.

This lets a user send a single message to a channel in a cabal from the `cabal` command. It will wait for a few seconds before quitting so that the swarm has a chance to pick up the change.

A command looks something like this:
`cabal --key cabal://asdf1234 --channel default --message “hello friends!”`

Thoughts?