### PR TITLE
Display MOTD/Topic on Channels

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -90,12 +90,26 @@ function Commander (view, cabal) {
       call: (arg) => {
         process.exit(0)
       }
+    },
+    motd: {
+      help: () => 'set the topic/description/`message of the day` for a channel',
+      call: (arg) => {
+        self.cabal.publish({
+          type: 'chat/motd',
+          content: {
+            channel: self.channel,
+            text: arg
+          }
+        })
+        self.view.writeLine('* motd set as: ' + arg)
+      }
     }
   }
   // add aliases to commands
   this.alias('join', 'j')
   this.alias('nick', 'n')
   this.alias('emote', 'me')
+  this.alias('motd', 'topic')
 }
 
 Commander.prototype.alias = function (command, alias) {

--- a/commands.js
+++ b/commands.js
@@ -91,17 +91,10 @@ function Commander (view, cabal) {
         process.exit(0)
       }
     },
-    motd: {
+    topic: {
       help: () => 'set the topic/description/`message of the day` for a channel',
       call: (arg) => {
-        self.cabal.publish({
-          type: 'chat/motd',
-          content: {
-            channel: self.channel,
-            text: arg
-          }
-        })
-        self.view.writeLine('* motd set as: ' + arg)
+        self.cabal.publishChannelTopic(self.channel, arg)
       }
     }
   }
@@ -109,7 +102,7 @@ function Commander (view, cabal) {
   this.alias('join', 'j')
   this.alias('nick', 'n')
   this.alias('emote', 'me')
-  this.alias('motd', 'topic')
+  this.alias('topic', 'motd')
 }
 
 Commander.prototype.alias = function (command, alias) {

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -233,6 +233,7 @@ NeatScreen.prototype.loadChannel = function (channel) {
   // clear the old channel state
   self.state.scrollback = 0
   self.state.messages = []
+  self.state.topic = ''
   self.neat.render()
 
   // MISSING: mention beeps
@@ -301,6 +302,10 @@ NeatScreen.prototype.formatMessage = function (msg) {
     if (emote) {
       authorText = `${chalk.white(author)}`
       content = `${chalk.gray(msg.value.content.text)}`
+    }
+    if (msg.value.type === 'chat/motd') {
+      self.state.topic = msg.value.content.text
+      content = chalk.gray(' * MOTD: ' + msg.value.content.text)
     }
 
     return timestamp + (emote ? ' * ' : ' ') + (highlight ? chalk.bgRed(chalk.black(authorText)) : authorText) + ' ' + content

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -163,6 +163,11 @@ function NeatScreen (cabal) {
           self.state.channels.sort()
           self.bus.emit('render')
         })
+
+        self.cabal.topics.events.on('update', function (msg) {
+          self.state.topic = msg.value.content.topic
+          self.bus.emit('render')
+        })
       })
 
       self.cabal.users.getAll(function (err, users) {
@@ -261,6 +266,14 @@ NeatScreen.prototype.loadChannel = function (channel) {
 
       self.neat.render()
 
+      self.cabal.topics.get(channel, (err, topic) => {
+        if (err) return
+        if (topic) {
+          self.state.topic = topic
+          self.neat.render()
+        }
+      })
+
       if (pending > 1) {
         pending = 0
         onMessage()
@@ -303,9 +316,8 @@ NeatScreen.prototype.formatMessage = function (msg) {
       authorText = `${chalk.white(author)}`
       content = `${chalk.gray(msg.value.content.text)}`
     }
-    if (msg.value.type === 'chat/motd') {
-      self.state.topic = msg.value.content.text
-      content = chalk.gray(' * MOTD: ' + msg.value.content.text)
+    if (msg.value.type === 'chat/topic') {
+      content = `${chalk.gray(`* ${self.state.channel} MOTD: ${msg.value.content.text}`)}`
     }
 
     return timestamp + (emote ? ' * ' : ' ') + (highlight ? chalk.bgRed(chalk.black(authorText)) : authorText) + ' ' + content

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "cabal": "cli.js"
   },
   "dependencies": {
-    "cabal-core": "^3.0.3",
+    "cabal-core": "^3.0.0",
     "chalk": "^2.4.1",
     "collect-stream": "^1.2.1",
     "discovery-swarm": "^5.1.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "cabal": "cli.js"
   },
   "dependencies": {
-    "cabal-core": "^3.0.0",
+    "cabal-core": "^3.0.3",
     "chalk": "^2.4.1",
     "collect-stream": "^1.2.1",
     "discovery-swarm": "^5.1.2",

--- a/views.js
+++ b/views.js
@@ -3,7 +3,7 @@ var chalk = require('chalk')
 var blit = require('txt-blit')
 var util = require('./util')
 
-const HEADER_ROWS = 6
+const HEADER_ROWS = 7
 
 module.exports = { big, small }
 
@@ -31,8 +31,13 @@ function big (state) {
   // channels pane
   blit(screen, renderChannels(state, 16, process.stdout.rows - HEADER_ROWS), 0, 3)
 
+  // channel topic description
+  if (state.topic) {
+    blit(screen, renderChannelTopic(state, process.stdout.columns - 17 - 17, process.stdout.rows - HEADER_ROWS), 18, 3)
+  }
+
   // chat messages
-  blit(screen, renderMessages(state, process.stdout.columns - 17 - 17, process.stdout.rows - HEADER_ROWS), 18, 3)
+  blit(screen, renderMessages(state, process.stdout.columns - 17 - 17, process.stdout.rows - HEADER_ROWS), 18, state.topic ? 4 : 3)
 
   // nicks pane
   blit(screen, renderNicks(state, 15, process.stdout.rows - HEADER_ROWS), process.stdout.columns - 15, 3)
@@ -118,6 +123,17 @@ function cmpUser (a, b) {
   if (b.name && !a.name) return 1
   if (a.name && b.name) return a.name < b.name ? -1 : 1
   return a.key < b.key ? -1 : 1
+}
+
+function renderChannelTopic (state, width, height) {
+  var topic = state.topic || state.channel
+  var line = '➤ ' + topic
+  line = line.substring(0, width - 1)
+  if (line.length === width - 1) {
+    line = line.substring(0, line.length - 1) + '…'
+  }
+  line = line + new Array(width - line.length - 1).fill(' ').join('')
+  return [chalk.bgBlue(chalk.white(line))]
 }
 
 function renderMessages (state, width, height) {


### PR DESCRIPTION
fixes #69 

This enables a new command called `/topic` (alias: `/motd`) to allow a user to set the topic of a channel.

Requires the cabal-core branch `MOTD`... https://github.com/cabal-club/cabal-core/pull/24

<img width="1121" alt="screen shot 2018-10-24 at 10 51 45 pm" src="https://user-images.githubusercontent.com/40796/47473154-70814900-d7df-11e8-9739-c946f60cc153.png">
