### PR TITLE
Add option to set maxFeeds of hypercores to replicate and set default to 1000

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -56,6 +56,7 @@ if (args.help || args.h) {
 var config
 var cabalKeys = []
 var configFilePath = findConfigPath()
+var maxFeeds = 1000
 
 // make sure the .cabal/v<databaseVersion> folder exists
 mkdirp.sync(rootdir)
@@ -135,6 +136,11 @@ if (args.join) {
   cabalKeys = [getKey(args.join)]
 }
 
+// set maximum number of hypercores to replicate
+if (args.maxFeeds) {
+  maxFeeds = args.maxFeeds
+}
+
 // only enable multi-cabal under the --experimental flag
 if (!args.experimental && cabalKeys.length) {
   var firstKey = cabalKeys[0]
@@ -145,7 +151,7 @@ if (!args.experimental && cabalKeys.length) {
 if (args.new) {
   var key = crypto.keyPair().publicKey.toString('hex')
   var db = archivesdir + key
-  var cabal = Cabal(db, key)
+  var cabal = Cabal(db, key, {maxFeeds: maxFeeds})
   cabal.db.ready(function () {
     if (!args.seed) {
       start([cabal])
@@ -156,7 +162,7 @@ if (args.new) {
   Promise.all(cabalKeys.map((key) => {
     key = key.replace('cabal://', '').replace('cbl://', '').replace('dat://', '').replace(/\//g, '')
     var db = archivesdir + key
-    var cabal = Cabal(db, key)
+    var cabal = Cabal(db, key, {maxFeeds: maxFeeds})
     return new Promise((resolve) => {
       cabal.db.ready(() => {
         resolve(cabal)
@@ -203,6 +209,7 @@ function start (cabals) {
       configFilePath,
       homedir,
       dbVersion,
+      maxFeeds,
       config,
       rootdir
     })
@@ -252,7 +259,7 @@ function saveConfig (path, config) {
 
 function publishSingleMessage ({key, channel, message, messageType, timeout}) {
   console.log(`Publishing message to channel - ${channel || 'default'}: ${message}`)
-  var cabal = Cabal(archivesdir + key, key)
+  var cabal = Cabal(archivesdir + key, key, {maxFeeds: maxFeeds})
   cabal.db.ready(() => {
     cabal.publish({
       type: messageType || 'chat/text',

--- a/neat-screen.js
+++ b/neat-screen.js
@@ -22,6 +22,7 @@ function NeatScreen (props) {
   this.rootdir = props.rootdir
   this.config = props.config
   this.isExperimental = props.isExperimental
+  this.maxFeeds = props.maxFeeds
 
   this.commander = Commander(this, props.cabals[0])
 
@@ -281,7 +282,7 @@ NeatScreen.prototype.addCabal = function (key) {
   if (!self.isExperimental) { return }
   key = key.replace('cabal://', '').replace('cbl://', '').replace('dat://', '').replace(/\//g, '')
   var db = this.archivesdir + key
-  var cabal = Cabal(db, key)
+  var cabal = Cabal(db, key, {maxFeeds: this.maxFeeds})
   cabal.db.ready(() => {
     self.state.cabals.push(cabal)
     swarm(cabal)


### PR DESCRIPTION
Requires https://github.com/cabal-club/cabal-core/pull/33

This passes the maxFeeds option all the way down to `hypercore-protocol` where the original limit was placed. 