### PR TITLE
Add --temp flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -41,6 +41,7 @@ var usage = `Usage
     --key     Specify a cabal key. Used with --alias
     --join    Only join the specified cabal, disregarding whatever is in the config
     --config  Specify a full path to a cabal config
+    --temp    Start the cli with a temporary in-memory database. Useful for debugging
 
     --message Publish a single message; then quit after \`timeout\`
     --channel Channel name to publish to for \`message\` option; default: "default"

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,8 +64,7 @@
     "ansi-escapes": {
       "version": "3.1.0",
       "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
-      "dev": true
+      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
     },
     "ansi-regex": {
       "version": "3.0.0",
@@ -1347,6 +1346,11 @@
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
+    "is-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-options/-/is-options-1.0.1.tgz",
+      "integrity": "sha512-2Xj8sA0zDrAcaoWfBiNmc6VPWAgKDpim0T3J9Djq7vbm1UjwbUWzeuLu/FwC46g3cBbAn0E5R0xwVtOobM6Xxg=="
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
@@ -2209,6 +2213,16 @@
         "random-access-storage": "^1.1.1"
       }
     },
+    "random-access-memory": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/random-access-memory/-/random-access-memory-3.1.1.tgz",
+      "integrity": "sha512-Qy1MliJDozZ1A6Hx3UbEnm8PPCfkiG/8CArbnhrxXMx1YRJPWipgPTB9qyhn4Z7WlLvCEqPb6Bd98OayyVuwrA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-options": "^1.0.1",
+        "random-access-storage": "^1.1.1"
+      }
+    },
     "random-access-storage": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-1.3.0.tgz",
@@ -2612,6 +2626,22 @@
         "has-flag": "^3.0.0"
       }
     },
+    "supports-hyperlinks": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-1.0.1.tgz",
+      "integrity": "sha512-HHi5kVSefKaJkGYXbDuKbUGRVxqnWGn3J2e39CYcNJEfWciGq2zYtOhXLTlvrOZW1QU7VX67w7fMmWafHX9Pfw==",
+      "requires": {
+        "has-flag": "^2.0.0",
+        "supports-color": "^5.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+        }
+      }
+    },
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
@@ -2624,6 +2654,15 @@
         "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
         "string-width": "^2.1.1"
+      }
+    },
+    "terminal-link": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-1.2.0.tgz",
+      "integrity": "sha512-nkM6NjuohxfZGA/jkAnM1zl2qjhdm8vZTG0Q36t+5O6msGwZ/ieJW+XxbIlLpUBQEUeGswg4XiB/QhcEVI23Rg==",
+      "requires": {
+        "ansi-escapes": "^3.1.0",
+        "supports-hyperlinks": "^1.0.1"
       }
     },
     "text-table": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "neat-log": "^3.1.0",
+    "random-access-memory": "^3.1.1",
     "strftime": "^0.10.0",
     "terminal-link": "^1.2.0",
     "through2": "^2.0.3",


### PR DESCRIPTION
Introduces a `--temp` flag as per https://github.com/cabal-club/cabal/issues/99.

This creates a  [`random-access-memory`](https://www.npmjs.com/package/random-access-memory) database and uses that instead of any locally saved databases. 
I think it should work with all the other connection options without a hitch.

Usage:
`cabal cabal://123...fad --temp`
`cabal pub --temp`