### PR TITLE
add support to cli for cabal dns entries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -310,6 +310,31 @@
         "xtend": "^4.0.1"
       }
     },
+    "cabal-dns": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cabal-dns/-/cabal-dns-1.0.1.tgz",
+      "integrity": "sha512-PQL3aGhLNoQ3jjK5xKSnaDvPMwI8nMlegZUyMxE0RT9z+SxZAKaaMXGHDJtJSU0iPRIoj4FlbEqMimX5uyyJqw==",
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "concat-stream": "^1.6.0",
+        "debug": "^4.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -321,7 +321,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
@@ -645,17 +645,6 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
-      }
-    },
-    "duplexify": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
-      "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
-      "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
       }
     },
     "emoji-regex": {
@@ -982,9 +971,9 @@
       }
     },
     "fast-bitfield": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/fast-bitfield/-/fast-bitfield-1.2.1.tgz",
-      "integrity": "sha512-OnsvI4w/LRwjv7y10ZTyRsl7A7ROV9SNBhr+sFVzqKjVHV1qCIESU5kHHcS1awJeE03Aa6X52F59HW+w0YI0lg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/fast-bitfield/-/fast-bitfield-1.2.2.tgz",
+      "integrity": "sha512-t8HYqkuE3YEqNcyWlAfh55479aTxO+GpYwvQvJppYqyBfSmRdNIhzY2m09FKN/MENTzq4wH6heHOIvsPyMAwvQ==",
       "requires": {
         "count-trailing-zeros": "^1.0.1"
       }
@@ -1006,6 +995,24 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fd-lock": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/fd-lock/-/fd-lock-1.0.2.tgz",
+      "integrity": "sha512-8O4zSv6rlNNghVfzVkj/p7LUIeBm7Xxk6QnhfmR1WJm/W4kwS8IyShy4X1peRnFUYZUYLlcwEMKXF8QWxJCMvg==",
+      "optional": true,
+      "requires": {
+        "napi-macros": "^1.8.2",
+        "node-gyp-build": "^3.8.0"
+      },
+      "dependencies": {
+        "node-gyp-build": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.8.0.tgz",
+          "integrity": "sha512-bYbpIHyRqZ7sVWXxGpz8QIRug5JZc/hzZH4GbdT9HTZi6WmKCZ8GLvP8OZ9TTiIBvwPFKgtGrlWQSXDAvYdsPw==",
+          "optional": true
+        }
+      }
     },
     "figures": {
       "version": "2.0.0",
@@ -1166,19 +1173,20 @@
       "dev": true
     },
     "hypercore": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-6.21.0.tgz",
-      "integrity": "sha512-LPKI+nvgbFTKbXD1y6It3PUZDIQFHSYIeSDbqIZeIVuSoeI4PYcCehKdqB9Wls31AIZL7cFwA5o64uOtBxF1cA==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/hypercore/-/hypercore-6.26.0.tgz",
+      "integrity": "sha512-su/bucp958SyFWWF5uzeLT05N0k7gTbktvLCo0TaloXWSSs2OiFyj3Ka7v93yaD9u0vBT3i0foPoZnj1yC/dog==",
       "requires": {
         "array-lru": "^1.1.0",
         "atomic-batcher": "^1.0.2",
         "bitfield-rle": "^2.2.1",
+        "buffer-alloc": "^1.2.0",
         "buffer-alloc-unsafe": "^1.0.0",
-        "buffer-equals": "^1.0.4",
         "buffer-from": "^1.0.0",
         "bulk-write-stream": "^1.1.3",
         "codecs": "^1.2.0",
-        "fast-bitfield": "^1.2.1",
+        "fast-bitfield": "^1.2.2",
+        "fd-lock": "^1.0.2",
         "flat-tree": "^1.6.0",
         "from2": "^2.3.0",
         "hypercore-crypto": "^1.0.0",
@@ -1190,7 +1198,7 @@
         "merkle-tree-stream": "^3.0.3",
         "pretty-hash": "^1.0.1",
         "process-nextick-args": "^1.0.7",
-        "random-access-file": "^2.0.1",
+        "random-access-file": "^2.1.0",
         "sodium-universal": "^2.0.0",
         "sparse-bitfield": "^3.0.0",
         "thunky": "^1.0.1",
@@ -1223,9 +1231,9 @@
       }
     },
     "hypercore-protocol": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-6.8.0.tgz",
-      "integrity": "sha512-WJOcnhiHAZpFVcvc1+tSmhcZaC76fQBKz6yyN1pFmhhqu8knNMOm6pcUFU2w+/mVFcXSbHhSfRtKwpNBu0EZSQ==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/hypercore-protocol/-/hypercore-protocol-6.9.0.tgz",
+      "integrity": "sha512-80kUQN6aZhdip4vHRhLyYrJ8Uhj34Xw1RdAtMwQNChoOlnVAvOzVh+ffIs6NiqBF4ExU25ToOvPTaYv+pYZBbg==",
       "requires": {
         "buffer-alloc-unsafe": "^1.0.0",
         "buffer-from": "^1.0.0",
@@ -1498,13 +1506,14 @@
       }
     },
     "kappa-core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/kappa-core/-/kappa-core-2.4.0.tgz",
-      "integrity": "sha512-sHkGWMwE/VpBXufjkQFtuHZvxUsgLT0L9drbXvmru5zCHrLUvgPg2D9AnFhCTfUgP3t5Dp7nEqrFNQHattTcBg==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/kappa-core/-/kappa-core-2.6.3.tgz",
+      "integrity": "sha512-g0U/BA857jpfD0aoux2r8Gqg13uti9D1nsvWS3VBs9q2ic8W5kBvu0gOiDb3SM2idiH7Ud6kEiTdrA5OYuD9KA==",
       "requires": {
-        "hypercore": "^6.18.1",
-        "multifeed": "^2.0.0",
-        "multifeed-index": "^3.0.1"
+        "hypercore": "^6.25.2",
+        "inherits": "^2.0.3",
+        "multifeed": "^3.0.3",
+        "multifeed-index": "^3.2.2"
       }
     },
     "kappa-view-level": {
@@ -1572,7 +1581,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
@@ -1707,9 +1716,9 @@
       }
     },
     "memory-pager": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.1.0.tgz",
-      "integrity": "sha512-Mf9OHV/Y7h6YWDxTzX/b4ZZ4oh9NSXblQL8dtPCOomOtZciEHxePR78+uHFLLlsk01A6jVHhHsQZZ/WcIPpnzg=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
     },
     "merkle-tree-stream": {
       "version": "3.0.3",
@@ -1775,23 +1784,21 @@
       }
     },
     "multifeed": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/multifeed/-/multifeed-2.0.5.tgz",
-      "integrity": "sha512-phy1wE3cJQS3CiLgRWixjz7ENAwDn3MkjqkIVXqO3VhACZ5Pm7DoI+bvuoGjaw0zkIaHRXEo1+gnGg/0p6BSjw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/multifeed/-/multifeed-3.0.3.tgz",
+      "integrity": "sha512-E/u63UX4nR8C+n5WPVtGuuK3qIJuK2eDuK4ZKTOAVqqGeeGYv8p0bzcZw66xcEk3iLPQXRB/82R5rPSAe7IUtA==",
       "requires": {
         "debug": "^4.1.0",
-        "hypercore-protocol": "^6.6.4",
+        "hypercore-protocol": "^6.8.0",
         "inherits": "^2.0.3",
         "mutexify": "^1.2.0",
-        "pumpify": "^1.5.1",
-        "random-access-file": "^2.0.1",
-        "through2": "^2.0.3"
+        "random-access-file": "^2.0.1"
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "requires": {
             "ms": "^2.1.1"
           }
@@ -1799,9 +1806,9 @@
       }
     },
     "multifeed-index": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/multifeed-index/-/multifeed-index-3.1.5.tgz",
-      "integrity": "sha512-36e4ajbdKfdLa8KzClI9Zg8+aBpEGsSXuOP058W6ugbxojSCUgGkRYJP6u/sP388R7WSTsruCFPCDlVgoyVMJw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/multifeed-index/-/multifeed-index-3.2.2.tgz",
+      "integrity": "sha512-jbuxeHQekdfcoavMRiWRu+DN+JLcmwlBCkC732fRtbDfAoqbb5WXCHA4K8+OeQIEYjPxZRTGdRfHY3gi80JOPw==",
       "requires": {
         "inherits": "^2.0.3"
       }
@@ -1863,6 +1870,12 @@
         "nanoassert": "^1.1.0",
         "nanoscheduler": "^1.0.2"
       }
+    },
+    "napi-macros": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-1.8.2.tgz",
+      "integrity": "sha512-Tr0DNY4RzTaBG2W2m3l7ZtFuJChTH6VZhXVhkGGjF/4cZTt+i8GcM9ozD+30Lmr4mDoZ5Xx34t2o4GJqYWDGcg==",
+      "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -2193,31 +2206,10 @@
         "once": "^1.3.1"
       }
     },
-    "pumpify": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-      "requires": {
-        "duplexify": "^3.6.0",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
-      }
-    },
     "random-access-file": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-2.0.1.tgz",
-      "integrity": "sha512-nb4fClpzoUY+v1SHrro+9yykN90eMA1rc+xM39tnZ5R3BgFY+J/NxPZ0KuUpishEsvnwou9Fvm2wa3cjeuG7vg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/random-access-file/-/random-access-file-2.1.1.tgz",
+      "integrity": "sha512-l8I6RlabShHmNPRqZ0f4mlHgkhgdrd5Prd4RXM9tOizUOMrTglKHB+s78pZZbIsJgny8E9gw0DRqCy3YVLxxZg==",
       "requires": {
         "mkdirp": "^0.5.1",
         "random-access-storage": "^1.1.1"
@@ -2579,11 +2571,6 @@
         "pkg-conf": "^2.0.0"
       }
     },
-    "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
-    },
     "strftime": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.10.0.tgz",
@@ -2601,7 +2588,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -2719,6 +2706,7 @@
       "version": "github:cblgh/txt-blit#fd97913448ec40ae344879c5ad10a0998c6a297b",
       "from": "github:cblgh/txt-blit",
       "requires": {
+        "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "cabal-core": "^4.0.0",
+    "cabal-dns": "^1.0.1",
     "chalk": "^2.4.1",
     "collect-stream": "^1.2.1",
     "discovery-swarm": "^5.1.2",


### PR DESCRIPTION
This PR uses a fork of [dat-dns](https://github.com/datprotocol/dat-dns). It supports everything dat-dns supports, but with the cabal:// prefix instead. 

Additionally, the cli config is used for persistent caching of resolved DNS entries.

The easiest way to pin a cabal key on a hostname is by creating a file called `cabal` in the webroot of your domain, inside a `.well-known` folder. See the record at https://cblgh.org/.well-known/cabal

We also don't invalidate resolved entries even if the TTL has expired, but a warning is added. If the ttl has expired however, and the domain is reachable and the `cabal` file present in `.well-known`, the new key will be resolved and cached locally.

Try it out against cabal://cblgh.org: `node cli.js cabal://cblgh.org`